### PR TITLE
Add JudyL and Judy1 bulk insert functions, some code cleanups

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -82,6 +82,12 @@ extern "C" {
     pub fn JudyLPrevEmpty(array: Pcvoid_t, pindex: *mut Word_t, err: PJError_t) -> c_int;
 
     pub fn Judy1Set(array: PPvoid_t, index: Word_t, err: PJError_t) -> c_int;
+    pub fn Judy1SetArray(
+        array: PPvoid_t,
+        count: Word_t,
+        keys: *const Word_t,
+        err: PJError_t,
+    ) -> c_int;
     pub fn Judy1Unset(array: PPvoid_t, index: Word_t, err: PJError_t) -> c_int;
     pub fn Judy1Test(array: Pcvoid_t, index: Word_t, err: PJError_t) -> c_int;
     pub fn Judy1Count(array: Pcvoid_t, index1: Word_t, index2: Word_t, err: PJError_t) -> Word_t;

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -53,6 +53,7 @@ extern "C" {
     pub fn JudyHSFreeArray(array: PPvoid_t, err: PJError_t) -> Word_t;
 
     pub fn JudyLIns(array: PPvoid_t, index: Word_t, err: PJError_t) -> PPvoid_t;
+    pub fn JudyLInsArray(array: PPvoid_t, count: Word_t, keys: *const Word_t, vals: *const Word_t, err: PJError_t) -> c_int;
     pub fn JudyLDel(array: PPvoid_t, index: Word_t, err: PJError_t) -> c_int;
     pub fn JudyLGet(array: Pcvoid_t, index: Word_t, err: PJError_t) -> PPvoid_t;
     pub fn JudyLCount(array: Pcvoid_t, index1: Word_t, index2: Word_t, err: PJError_t) -> Word_t;

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(clippy::upper_case_acronyms)]
 
 extern crate libc;
 use self::libc::{c_int, c_ulong, c_void};
@@ -53,7 +54,13 @@ extern "C" {
     pub fn JudyHSFreeArray(array: PPvoid_t, err: PJError_t) -> Word_t;
 
     pub fn JudyLIns(array: PPvoid_t, index: Word_t, err: PJError_t) -> PPvoid_t;
-    pub fn JudyLInsArray(array: PPvoid_t, count: Word_t, keys: *const Word_t, vals: *const Word_t, err: PJError_t) -> c_int;
+    pub fn JudyLInsArray(
+        array: PPvoid_t,
+        count: Word_t,
+        keys: *const Word_t,
+        vals: *const Word_t,
+        err: PJError_t,
+    ) -> c_int;
     pub fn JudyLDel(array: PPvoid_t, index: Word_t, err: PJError_t) -> c_int;
     pub fn JudyLGet(array: Pcvoid_t, index: Word_t, err: PJError_t) -> PPvoid_t;
     pub fn JudyLCount(array: Pcvoid_t, index1: Word_t, index2: Word_t, err: PJError_t) -> Word_t;

--- a/src/judy1.rs
+++ b/src/judy1.rs
@@ -21,6 +21,9 @@ impl Judy1 {
         prev == 1
     }
 
+    /// Warning: This function requires the keys to be sorted in relation to data already in the array.
+    /// That means even if this set of keys is sorted, if it's out of sequence with the keys in
+    /// the array then the function will fail.
     pub fn set_bulk_sorted(&mut self, count: Word_t, keys: &[Word_t]) -> bool {
         assert!(
             keys.len() as u64 >= count,

--- a/src/judy1.rs
+++ b/src/judy1.rs
@@ -5,6 +5,12 @@ pub struct Judy1 {
     m: Pvoid_t,
 }
 
+impl Default for Judy1 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Judy1 {
     pub fn new() -> Judy1 {
         Judy1 { m: null_mut() }
@@ -25,10 +31,10 @@ impl Judy1 {
     }
 
     pub fn free(&mut self) -> Word_t {
-        if self.m != null_mut() {
+        if self.m.is_null() {
             unsafe {
                 let ret = Judy1FreeArray(&mut self.m, null_mut());
-                assert!(self.m == null_mut());
+                assert!(self.m.is_null());
                 ret
             }
         } else {
@@ -36,7 +42,7 @@ impl Judy1 {
         }
     }
 
-    pub fn iter<'a>(&'a self) -> Judy1Iterator<'a> {
+    pub fn iter(&self) -> Judy1Iterator<'_> {
         Judy1Iterator { j: self, i: 0 }
     }
 
@@ -53,7 +59,7 @@ impl Judy1 {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.m == null_mut()
+        self.m.is_null()
     }
 }
 
@@ -65,7 +71,7 @@ pub struct Judy1Iterator<'a> {
 impl<'a> Iterator for Judy1Iterator<'a> {
     type Item = Word_t;
 
-    fn next(&mut self) -> Option<(Word_t)> {
+    fn next(&mut self) -> Option<Word_t> {
         unsafe {
             let v = Judy1Next(self.j.m, &mut self.i, null_mut());
             if v == 0 {

--- a/src/judy1.rs
+++ b/src/judy1.rs
@@ -21,6 +21,17 @@ impl Judy1 {
         prev == 1
     }
 
+    pub fn set_bulk_sorted(&mut self, count: Word_t, keys: &[Word_t]) -> bool {
+        assert!(
+            keys.len() as u64 >= count,
+            "Judy1::set_bulk_sorted: Keys array shorter than count argument!"
+        );
+        unsafe {
+            let result = Judy1SetArray(&mut self.m, count, keys.as_ptr(), null_mut());
+            result == 0 || result == 1
+        }
+    }
+
     pub fn unset(&mut self, index: Word_t) -> bool {
         let prev = unsafe { Judy1Unset(&mut self.m, index, null_mut()) };
         prev == 1

--- a/src/judyhs.rs
+++ b/src/judyhs.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 use super::capi::*;
 use std::marker::PhantomData;
 use std::mem::size_of;
@@ -10,37 +12,43 @@ pub trait SizedPtr {
 
 impl SizedPtr for str {
     fn len(&self) -> usize {
-        return self.len();
+        self.len()
     }
 
     fn as_ptr(&self) -> *const u8 {
-        return self.as_ptr();
+        self.as_ptr()
     }
 }
 
 impl<K> SizedPtr for [K] {
     fn len(&self) -> usize {
-        return self.len();
+        self.len()
     }
 
     fn as_ptr(&self) -> *const u8 {
-        return self.as_ptr() as *const u8;
+        self.as_ptr() as *const u8
     }
 }
 
 impl<K> SizedPtr for K {
     fn len(&self) -> usize {
-        return size_of::<K>();
+        size_of::<K>()
     }
 
     fn as_ptr(&self) -> *const u8 {
-        return self as *const K as *const u8;
+        self as *const K as *const u8
     }
 }
 
 pub struct JudyHS<K: ?Sized> {
     m: Pvoid_t,
     key_type: PhantomData<*const K>,
+}
+
+impl<K: ?Sized> Default for JudyHS<K> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<K: ?Sized> JudyHS<K> {
@@ -52,9 +60,9 @@ impl<K: ?Sized> JudyHS<K> {
     }
 
     pub fn free(&mut self) -> Word_t {
-        if self.m != null_mut() {
+        if !self.m.is_null() {
             let ret = unsafe { JudyHSFreeArray(&mut self.m, null_mut()) };
-            assert!(self.m == null_mut());
+            assert!(self.m.is_null());
             ret
         } else {
             0
@@ -66,7 +74,7 @@ impl<K: ?Sized> JudyHS<K> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.m == null_mut()
+        self.m.is_null()
     }
 }
 
@@ -79,9 +87,7 @@ impl<K: SizedPtr + ?Sized> JudyHS<K> {
                 key.len() as Word_t,
                 null_mut(),
             );
-            if v == null_mut() {
-                false
-            } else if *v != null_mut() {
+            if v.is_null() || !(*v).is_null() {
                 false
             } else {
                 *v = value as Pvoid_t;
@@ -93,7 +99,7 @@ impl<K: SizedPtr + ?Sized> JudyHS<K> {
     pub fn get(&self, key: &K) -> Option<Word_t> {
         unsafe {
             let v = JudyHSGet(self.m, key.as_ptr() as Pcvoid_t, key.len() as Word_t);
-            if v == null_mut() {
+            if v.is_null() {
                 None
             } else {
                 Some(*v as Word_t)

--- a/src/judyl.rs
+++ b/src/judyl.rs
@@ -13,6 +13,7 @@ impl JudyL {
     pub fn insert(&mut self, index: Word_t, value: Word_t) -> bool {
         unsafe {
             let v = JudyLIns(&mut self.m, index, null_mut());
+            #[allow(clippy::if_same_then_else)]
             if v == null_mut() {
                 false
             } else if *v != null_mut() {
@@ -22,6 +23,15 @@ impl JudyL {
                 true
             }
         }
+    }
+
+    pub fn insert_bulk_sorted(&mut self, count: Word_t, keys: &[Word_t], vals: &[Word_t]) -> bool {
+        assert!(keys.len() as u64 >= count && vals.len() as u64 >= count, "insertBulk: Array less than passed count!");
+        unsafe {
+            let result = JudyLInsArray(&mut self.m, count, keys.as_ptr(), vals.as_ptr(), null_mut());
+            result == 0 || result == 1
+        }
+
     }
 
     pub fn get(&self, index: Word_t) -> Option<Word_t> {

--- a/src/judyl.rs
+++ b/src/judyl.rs
@@ -28,6 +28,9 @@ impl JudyL {
         }
     }
 
+    /// Warning: This function requires the keys to be sorted in relation to data already in the array.
+    /// That means even if this set of keys is sorted, if it's out of sequence with the keys in
+    /// the array then the function will fail.
     pub fn insert_bulk_sorted(&mut self, count: Word_t, keys: &[Word_t], vals: &[Word_t]) -> bool {
         assert!(
             keys.len() as u64 >= count && vals.len() as u64 >= count,


### PR DESCRIPTION
This pull adds support for `JudyLInsArray` and `Judy1SetArray` functions as `JudyL::insert_bulk_sorted` and `Judy1::set_bulk_sorted` respectively. 

I also ran the files through `rustfmt` and tried to add some cleanups on the advice of Clippy. I didn't mess with the naming conventions but I did add some pragmas to suppress warnings about them. 

I added some `Default` instances that just call the corresponding `::new()` functions.

The cleanup changes to `null_mut()` comparisons and the `if/else if/else`  parts should probably be double checked. Clippy told me to do it, but it is possible I have erred. It does seem to still work.

Closes #1